### PR TITLE
fix small bug when directory doesn't exist

### DIFF
--- a/setup-utilities.sh
+++ b/setup-utilities.sh
@@ -53,8 +53,14 @@ link_config() {
   copy_only=${4:-false}
   [[ $as_root = true ]] && as_user="sudo" || as_user=""
   [[ $copy_only = true ]] && command="cp" || command="ln -s"
-  # create and move to backup if exists
-  mkdir -p "$(dirname "$dst")"
-  backup_dst_config "$dst" "$as_user"
+  
+  if [ -d $dst ]; then
+    # create and move to backup if exists
+    backup_dst_config $dst $as_user
+  else
+    # make directory if it doesn't exist currently
+    mkdir -p $dst
+  fi
+
   $as_user $command "$src" "$dst"
 }


### PR DESCRIPTION
If a directory doesn't exist, the deleted code will create an empty directory, back it up, and them sym-link. The edited code addresses this small bug